### PR TITLE
Use caffeine instead of pair set

### DIFF
--- a/interfaces/src/main/kotlin/com/noxcrew/interfaces/properties/DelegateTrigger.kt
+++ b/interfaces/src/main/kotlin/com/noxcrew/interfaces/properties/DelegateTrigger.kt
@@ -1,13 +1,15 @@
 package com.noxcrew.interfaces.properties
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import java.util.Queue
+import java.util.concurrent.ConcurrentLinkedDeque
 
 /** A trigger that delegates triggers to its listeners. */
 public open class DelegateTrigger : Trigger {
 
     private val updateListeners = Caffeine.newBuilder()
         .weakKeys()
-        .build<Any, MutableList<Any.() -> Unit>>()
+        .build<Any, Queue<Any.() -> Unit>>()
         .asMap()
 
     override fun trigger() {
@@ -19,7 +21,7 @@ public open class DelegateTrigger : Trigger {
     override fun <T : Any> addListener(reference: T, listener: T.() -> Unit) {
         @Suppress("UNCHECKED_CAST")
         updateListeners.computeIfAbsent(reference) {
-            mutableListOf()
+            ConcurrentLinkedDeque()
         }.add(listener as (Any.() -> Unit))
     }
 }

--- a/interfaces/src/main/kotlin/com/noxcrew/interfaces/properties/DelegateTrigger.kt
+++ b/interfaces/src/main/kotlin/com/noxcrew/interfaces/properties/DelegateTrigger.kt
@@ -1,28 +1,25 @@
 package com.noxcrew.interfaces.properties
 
-import java.lang.ref.WeakReference
-import java.util.concurrent.ConcurrentHashMap
+import com.github.benmanes.caffeine.cache.Caffeine
 
 /** A trigger that delegates triggers to its listeners. */
 public open class DelegateTrigger : Trigger {
 
-    private val updateListeners = ConcurrentHashMap.newKeySet<Pair<WeakReference<Any>, Any.() -> Unit>>()
+    private val updateListeners = Caffeine.newBuilder()
+        .weakKeys()
+        .build<Any, MutableList<Any.() -> Unit>>()
+        .asMap()
 
     override fun trigger() {
-        val iterator = updateListeners.iterator()
-        while (iterator.hasNext()) {
-            val (reference, consumer) = iterator.next()
-            val obj = reference.get()
-            if (obj == null) {
-                iterator.remove()
-                continue
-            }
-            obj.apply(consumer)
+        updateListeners.forEach { (_, listeners) ->
+            listeners.forEach { it() }
         }
     }
 
     override fun <T : Any> addListener(reference: T, listener: T.() -> Unit) {
-        updateListeners.removeIf { it.first.get() == null }
-        updateListeners.add(WeakReference(reference) as WeakReference<Any> to listener as (Any.() -> Unit))
+        @Suppress("UNCHECKED_CAST")
+        updateListeners.computeIfAbsent(reference) {
+            mutableListOf()
+        }.add(listener as (Any.() -> Unit))
     }
 }


### PR DESCRIPTION
Currently using a set of pairs of weak reference to listener and only removing based on null references on trigger means it'll only get rid of references if there is a trigger. In a situation where the trigger is held and never trigger the set will never empty.
Replacing it with a caffeine cache with weak keys and a list of listeners as value will make it so all listeners get instantly removed when the reference gets garbage collected.