### PR TITLE
feature: Add ClickContext#interact to allow determining if the click is from an interact event

### DIFF
--- a/interfaces/src/main/kotlin/com/noxcrew/interfaces/InterfacesListeners.kt
+++ b/interfaces/src/main/kotlin/com/noxcrew/interfaces/InterfacesListeners.kt
@@ -252,7 +252,7 @@ public class InterfacesListeners private constructor(private val plugin: Plugin)
         val isPlayerInventory = (event.clickedInventory ?: event.inventory).holder is Player
 
         // Run base click handling
-        if (handleClick(view, clickedPoint, event.click, event.hotbarButton, isPlayerInventory)) {
+        if (handleClick(view, clickedPoint, event.click, event.hotbarButton, isPlayerInventory, false)) {
             event.isCancelled = true
         }
 
@@ -415,7 +415,7 @@ public class InterfacesListeners private constructor(private val plugin: Plugin)
             return
         }
 
-        if (handleClick(view, clickedPoint, click, -1, true)) {
+        if (handleClick(view, clickedPoint, click, -1, isPlayerInventory = true, interact = true)) {
             // Support modern behavior where we don't interfere with block interactions
             if (view.builder.onlyCancelItemInteraction) {
                 event.setUseItemInHand(Event.Result.DENY)
@@ -557,7 +557,8 @@ public class InterfacesListeners private constructor(private val plugin: Plugin)
         clickedPoint: GridPoint,
         click: ClickType,
         slot: Int,
-        isPlayerInventory: Boolean
+        isPlayerInventory: Boolean,
+        interact: Boolean
     ): Boolean {
         // Determine the type of click, if nothing was clicked we allow it
         val raw = view.pane.getRaw(clickedPoint)
@@ -581,7 +582,7 @@ public class InterfacesListeners private constructor(private val plugin: Plugin)
         view.isProcessingClick = true
 
         // Forward this click to all pre-processors
-        val clickContext = ClickContext(view.player, view, click, slot)
+        val clickContext = ClickContext(view.player, view, click, slot, interact)
         view.builder.clickPreprocessors
             .forEach { handler -> ClickHandler.process(handler, clickContext) }
 

--- a/interfaces/src/main/kotlin/com/noxcrew/interfaces/click/ClickContext.kt
+++ b/interfaces/src/main/kotlin/com/noxcrew/interfaces/click/ClickContext.kt
@@ -13,5 +13,7 @@ public data class ClickContext(
     /** The type of click that was performed. */
     public val type: ClickType,
     /** The hot bar slot pressed between 0-8 if [type] is [ClickType.NUMBER_KEY], or `-1` otherwise. */
-    public val slot: Int
+    public val slot: Int,
+    /** Whether the click was fired from an interact event (not from an open inventory). */
+    public val interact: Boolean
 )


### PR DESCRIPTION
Adds a simple boolean property to `ClickContext` that can be used to determine if the click was fired from an interact event or not.