### PR TITLE
Fix IncompatibleClassChangeError with allowClickingOwnInventoryIfClickingEmptySlotsIsPrevented

### DIFF
--- a/interfaces/src/main/kotlin/com/noxcrew/interfaces/interfaces/InterfaceProperties.kt
+++ b/interfaces/src/main/kotlin/com/noxcrew/interfaces/interfaces/InterfaceProperties.kt
@@ -47,12 +47,12 @@ public open class InterfaceProperties<P : Pane> {
      * [ChestInterfaceBuilder].
      */
     public var allowClickingOwnInventoryIfClickingEmptySlotsIsPrevented: Boolean = false
-        get() {
-            // This setting is not allowed on non-chest interfaces!
-            if (this !is ChestInterfaceBuilder) {
-                return false
+        set(value) {
+            field = if (this !is ChestInterfaceBuilder) {
+                false
+            } else {
+                value
             }
-            return field
         }
 
     /**


### PR DESCRIPTION
Workaround error by using setter instead of getter, seems to stop the error occurring

Can reproduce with the `changing-title` interface in the example plugin, the error no longer happens after applying this fix

The error occurring without this fix:

```
[20:54:49 INFO]: nentify issued server command: /interfaces changing-title
[20:54:50 ERROR]: Could not pass event InventoryClickEvent to ExamplePlugin v1.0.0
java.lang.IncompatibleClassChangeError: Expected static field com.noxcrew.interfaces.interfaces.InterfaceProperties.allowClickingOwnInventoryIfClickingEmptySlotsIsPrevented
	at examples-1.4.0-SNAPSHOT-all-1740257483495.jar/com.noxcrew.interfaces.interfaces.InterfaceProperties.getAllowClickingOwnInventoryIfClickingEmptySlotsIsPrevented(InterfaceProperties.kt:55) ~[examples-1.4.0-SNAPSHOT-all-1740257483495.jar:?]
	at examples-1.4.0-SNAPSHOT-all-1740257483495.jar/com.noxcrew.interfaces.InterfacesListeners.handleClick(InterfacesListeners.kt:620) ~[examples-1.4.0-SNAPSHOT-all-1740257483495.jar:?]
	at examples-1.4.0-SNAPSHOT-all-1740257483495.jar/com.noxcrew.interfaces.InterfacesListeners.onClick(InterfacesListeners.kt:303) ~[examples-1.4.0-SNAPSHOT-all-1740257483495.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleContainerClick(ServerGamePacketListenerImpl.java:3195) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:69) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:14) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:29) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:155) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1448) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:176) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:129) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1428) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1422) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:139) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:1379) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1387) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1264) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310) ~[paper-1.21.4.jar:1.21.4-177-e5a8ee8]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```