### PR TITLE
api: allow getting the current title of a ChestInterfaceView

### DIFF
--- a/interfaces/src/main/kotlin/com/noxcrew/interfaces/view/ChestInterfaceView.kt
+++ b/interfaces/src/main/kotlin/com/noxcrew/interfaces/view/ChestInterfaceView.kt
@@ -28,6 +28,8 @@ public class ChestInterfaceView internal constructor(
         titleState.current = value
     }
 
+    public fun title(): Component? = titleState.current
+
     override fun createInventory(): ChestInterfacesInventory = ChestInterfacesInventory(
         holder = this,
         title = titleState.current,


### PR DESCRIPTION
This tiny PR adds a `title(): Component?` function to ChestInterfaceView which returns the current title of the interface.